### PR TITLE
fix(types): replace 'export type *' with 'export *' for type modules

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -21,11 +21,11 @@ limitations under the License.
  * Remember to only export *public* types from this file.
  */
 
-export type * from "./@types/media";
+export * from "./@types/media";
 export * from "./@types/membership";
-export type * from "./@types/event";
-export type * from "./@types/events";
-export type * from "./@types/state_events";
+export * from "./@types/event";
+export * from "./@types/events";
+export * from "./@types/state_events";
 
 /** The different methods for device and user verification */
 export enum VerificationMethod {


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible).
-   [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
-   [ ] Linter and other CI checks pass.
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md)).
